### PR TITLE
Change regex to allow space between function name and parentheses

### DIFF
--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -139,7 +139,7 @@ export default {
     for (var row = pos.row; row--; row > 0) {
       let line = buffer.lineForRow(row);
       if (line.includes('function ')) {
-        let parts = line.match('function ([^\\(]+)\\(');
+        let parts = line.match(/function\s+([^\s(]+)\s*\(/);
         if (parts && parts.length > 1)
           return parts[1];
       }


### PR DESCRIPTION
This changes regex used to get the name of the test function, allowing functions to be defined with space between function name and parentheses.

Example:
```php
function testExample () {
    $this->assertTrue(true);
}
```