### PR TITLE
Fix path used as cwd for running test when multiple project folders are opened

### DIFF
--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -83,13 +83,13 @@ export default {
       this.errorView.update('No Output');
       this.outputPanel.hide();
     }
-    filename = this.getFilepath();
-    if (!filename) {
+    filepath = this.getFilepath();
+    if (!filepath) {
       atom.notifications.addError('Failed to get filename! Make sure you are in the test file you want run.');
       return;
     }
 
-    this.execute(filename);
+    this.execute(filepath);
   },
 
   runSuite() {
@@ -97,6 +97,13 @@ export default {
       this.errorView.update('No Output');
       this.outputPanel.hide();
     }
+
+    filepath = this.getFilepath();
+    if (!filepath) {
+      atom.notifications.addError('Failed to find phpunit! Make sure you are in the test file from the suit you want run.');
+      return;
+    }
+
     this.execute();
   },
 
@@ -120,7 +127,7 @@ export default {
 
     console.log(`atom-phpunit: ${cmd}`);
 
-    this.exec(cmd, {cwd: atom.project.getPaths()[0]}, (error, stdout, stderr) => {
+    this.exec(cmd, {cwd: this.getProjectFolderPath()}, (error, stdout, stderr) => {
       if (error && stderr) {
         this.errorView.update(stderr, false);
         this.outputPanel.show();
@@ -173,7 +180,11 @@ export default {
       return false;
     }
 
-    return file.path.replace(`${atom.project.getPaths()[0]}/`, '');
-  }
+    return file.path;
+  },
 
+  getProjectFolderPath() {
+    return atom.project.relativizePath(this.getFilepath())[0];
+  }
+  
 };


### PR DESCRIPTION
This fixes issue #4 and error notification is displayed when there are no files opened.

It's a bit difficult getting the project path when we have no starting point in form of an open file. There might be other solutions, but for the moment I present this one.