### PR TITLE
Update output view as PHPUnit runs

### DIFF
--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -127,7 +127,26 @@ export default {
 
     console.log(`atom-phpunit: ${cmd}`);
 
-    this.exec(cmd, {cwd: this.getProjectFolderPath()}, (error, stdout, stderr) => {
+    const phpunit = this.exec(cmd, {cwd: this.getProjectFolderPath()})
+
+    let stdout = ""
+    let stderr = ""
+
+    phpunit.stdout.on("data", (data) => {
+      stdout += data.toString()
+
+      this.errorView.update(stdout, false);
+    });
+
+    phpunit.stderr.on("data", (data) => {
+      stderr += data.toString()
+
+      this.errorView.update(stderr, false);
+    });
+
+    phpunit.on('exit', (code) => {
+      const error = code.toString() !== '0'
+
       if (error && stderr) {
         this.errorView.update(stderr, false);
         this.outputPanel.show();


### PR DESCRIPTION
I found myself wanting live PHPUnit output (I have some test suites that take a 15–30s to run) so I wanted to PR this to open a discussion.

Right now it doesn't open the output panel when output is immediately received. I've done this to be consistent with current behavior but perhaps this should be configurable?

What are your thoughts on the approach I took? I tried to make as few changes as possible. I'm not 100% on the way I handled interactive stdout & stderr streams. The output view could conceivable switch between the two until the test is finished.

Perhaps the output should be concatenated from both streams and displayed that way all the time?