### PR TITLE
Change keymap for toogle-output

### DIFF
--- a/keymaps/atom-phpunit.json
+++ b/keymaps/atom-phpunit.json
@@ -4,6 +4,6 @@
     "alt-shift-c": "atom-phpunit:run-class",
     "alt-shift-s": "atom-phpunit:run-suite",
     "alt-shift-r": "atom-phpunit:run-last-test",
-    "alt-shift-x": "atom-phpunit:toggle-output"
+    "escape": "atom-phpunit:toggle-output"
   }
 }

--- a/keymaps/atom-phpunit.json
+++ b/keymaps/atom-phpunit.json
@@ -3,7 +3,9 @@
     "alt-shift-t": "atom-phpunit:run-test",
     "alt-shift-c": "atom-phpunit:run-class",
     "alt-shift-s": "atom-phpunit:run-suite",
-    "alt-shift-r": "atom-phpunit:run-last-test",
-    "escape": "atom-phpunit:toggle-output"
+    "alt-shift-r": "atom-phpunit:run-last-test",    
+  }
+  'atom-workspace atom-text-editor:not([mini])': {
+    'escape': 'atom-phpunit:toggle-output',
   }
 }

--- a/keymaps/atom-phpunit.json
+++ b/keymaps/atom-phpunit.json
@@ -3,9 +3,9 @@
     "alt-shift-t": "atom-phpunit:run-test",
     "alt-shift-c": "atom-phpunit:run-class",
     "alt-shift-s": "atom-phpunit:run-suite",
-    "alt-shift-r": "atom-phpunit:run-last-test",    
+    "alt-shift-r": "atom-phpunit:run-last-test"    
   },
-  'atom-workspace atom-text-editor:not([mini])': {
-    'escape': 'atom-phpunit:toggle-output',
+  "atom-workspace atom-text-editor:not([mini])": {
+    "escape': 'atom-phpunit:toggle-output"
   }
 }

--- a/keymaps/atom-phpunit.json
+++ b/keymaps/atom-phpunit.json
@@ -4,7 +4,7 @@
     "alt-shift-c": "atom-phpunit:run-class",
     "alt-shift-s": "atom-phpunit:run-suite",
     "alt-shift-r": "atom-phpunit:run-last-test",    
-  }
+  },
   'atom-workspace atom-text-editor:not([mini])': {
     'escape': 'atom-phpunit:toggle-output',
   }


### PR DESCRIPTION
As suggested in #12 and I think it's pretty helpful, let's make it: `Esc` to toggle the output panel (without losing the real `Esc` funcionallity in the Command Palette) :o:  