### PR TITLE
Add fix for php path issues

### DIFF
--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -45,6 +45,12 @@ export default {
   exec: null,
 
   activate(state) {
+    process.env.PATH = String(
+        child_process.execFileSync(
+            process.env.SHELL,
+            ['-c', 'source $HOME/.bash_profile; echo $PATH']
+        )
+    ).trim()
     this.exec = child_process.exec;
     this.storage = new Storage;
     this.errorView = new AtomPhpunitView(state.atomPhpunitViewState);


### PR DESCRIPTION
I ran into an issue where running PHPUnit tests in atom would give an error stating that the version of PHPUnit I had required a more recent version of PHP because Mac's built in PHP (version 5.5 at /usr/bin/php) was being used instead of the version I installed with Homebrew.

This commit fixes that issue by first trying to grab the $PATH from the current user's .bash_profile which will then allow the version of PHP the user has in his $PATH to always be used instead of trying to use the built in PHP version.