### PR TITLE
Pending Tests

### DIFF
--- a/lib/atom-phpunit-view.js
+++ b/lib/atom-phpunit-view.js
@@ -49,10 +49,8 @@ export default class AtomPhpunitView {
     return this.element;
   }
 
-  update(data, cmd, success) {
-    success
-      ? this.element.classList.remove('error')
-      : this.element.classList.add('error');
+  update(data, cmd, success, pending = false) {
+    this.setElementClass(pending ? 'pending' : (success ? 'success' : 'error'));
 
     this.element.children[0].innerHTML = this.getUpdatedHeader(data, cmd);
     this.element.children[1].children[0].innerHTML = this.getCleanOutput(data);
@@ -111,6 +109,11 @@ export default class AtomPhpunitView {
       /(Time: [\d\. \w]+, Memory: [\d\. \w]+)\n*/i,
       /(PHPUnit [\d\. \w]+)\n+/i,
     ];
+  }
+
+  setElementClass(className) {
+    this.element.classList.remove('pending', 'success', 'error');
+    this.element.classList.add(className);
   }
 
 }

--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -184,14 +184,14 @@ export default {
     let stderr = ""
 
     if (!atom.config.get('atom-phpunit.failuresAsNotifications')) {
-      this.errorView.update('', false);
+      this.errorView.update('', false, true);
       this.outputPanel.show();
     }
 
     phpunit.stdout.on("data", (data) => {
       stdout += data.toString()
 
-      this.errorView.update(stdout, false);
+      this.errorView.update(stdout, false, true);
     });
 
     phpunit.stderr.on("data", (data) => {

--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -184,7 +184,7 @@ export default {
     let stderr = ""
 
     if (!atom.config.get('atom-phpunit.failuresAsNotifications')) {
-      this.errorView.update('', false, true);
+      this.errorView.update('', cmd, false, true);
       this.outputPanel.show();
     }
 

--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -183,6 +183,11 @@ export default {
     let stdout = ""
     let stderr = ""
 
+    if (!atom.config.get('atom-phpunit.failuresAsNotifications')) {
+      this.errorView.update('', false);
+      this.outputPanel.show();
+    }
+
     phpunit.stdout.on("data", (data) => {
       stdout += data.toString()
 

--- a/styles/atom-phpunit.less
+++ b/styles/atom-phpunit.less
@@ -38,4 +38,13 @@
       background-color: #660000;
     }
   }
+
+  &.pending {
+    border-left-color: #FFF17A;
+
+    .header {
+      background-color: #FFF17A;
+      color: #000000;
+    }
+  }
 }


### PR DESCRIPTION
This includes #16 which updates the output view as PHPUnit runs. It also clears old data and displays the output panel immediately if notifications aren't used. And it adds a pending css class to give a visual indicator that the tests are still running.