### PR TITLE
Pull out important information to header and link up filepaths

### DIFF
--- a/lib/atom-phpunit-view.js
+++ b/lib/atom-phpunit-view.js
@@ -23,6 +23,12 @@ export default class AtomPhpunitView {
     output.classList.add('output');
     output.style.fontSize = atom.config.get('atom-phpunit.outputViewFontSize');
 
+    output.addEventListener("click", function(e) {
+      if(e.target && e.target.nodeName == "A") {
+        atom.open({pathsToOpen: [e.target.textContent]});
+      }
+    });
+
     atom.config.observe('atom-phpunit.outputViewFontSize', (newValue) => {
       output.style.fontSize = newValue;
     })
@@ -43,12 +49,68 @@ export default class AtomPhpunitView {
     return this.element;
   }
 
-  update(data, success) {
+  update(data, cmd, success) {
     success
       ? this.element.classList.remove('error')
       : this.element.classList.add('error');
 
-    this.element.children[1].children[0].textContent = data;
+    this.element.children[0].innerHTML = this.getUpdatedHeader(data, cmd);
+    this.element.children[1].children[0].innerHTML = this.getCleanOutput(data);
+  }
+
+  getUpdatedHeader(data, cmd) {
+    let info = [], matches, header = 'PHPUnit Output';
+
+    this.getRegexPatterns().forEach(pattern => {
+      if (matches = data.match(pattern)) {
+        info.push(`<span>${matches[1]}</span>`);
+      }
+    });
+
+    if (info.length) {
+      header = '';
+      info[0] = `<strong>${info[0]}</strong>`;
+
+      if (cmd = this.getParsedCommand(cmd)) {
+        header += `<div>${cmd}</div>`;
+      }
+
+      header += info.join('<span class="divider"> | </span>');
+    }
+
+    return header;
+  }
+
+  getParsedCommand(cmd) {
+    let info = [], matches;
+    [/phpunit [\/\w- _=]+\/(\w+)(?:.php)?$/i, /--filter=([\w_]+)/i].forEach(pattern => {
+      if (matches = cmd.match(pattern)) {
+        info.push(matches[1]);
+      }
+    });
+
+    return info.join('::');
+  }
+
+  getCleanOutput(input) {
+    this.getRegexPatterns().forEach(pattern => {
+      input = input.replace(pattern, '');
+    });
+
+    input = input.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
+      return '&#'+i.charCodeAt(0)+';';
+    });
+    input = input.replace(/((([A-Z]\\:)?([\\/]+(\w|-|_|\.)+)+(\.(\w|-|_)+)+(:\d+)?))/g, '<a>$1</a>');
+
+    return input.trim();
+  }
+
+  getRegexPatterns() {
+    return [
+      /\n+(?:Failures!\n)?(OK \([\d,\w ]+\)|Tests: \d+, Assertions: \d+, (?:Failures|Risky): \d+)\.?\n*/i,
+      /(Time: [\d\. \w]+, Memory: [\d\. \w]+)\n*/i,
+      /(PHPUnit [\d\. \w]+)\n+/i,
+    ];
   }
 
 }

--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -169,17 +169,17 @@ export default {
 
     this.exec(cmd, {cwd: this.getProjectFolderPath()}, (error, stdout, stderr) => {
       if (error && stderr) {
-        this.errorView.update(stderr, false);
+        this.errorView.update(stderr, cmd, false);
         this.outputPanel.show();
       } else if (error) {
-        this.errorView.update(stdout, false);
+        this.errorView.update(stdout, cmd, false);
         if (atom.config.get('atom-phpunit.failuresAsNotifications')) {
           atom.notifications.addError('Test Failed!', {description: cmd, detail: stdout});
         } else {
           this.outputPanel.show();
         }
       } else {
-        this.errorView.update(stdout, true);
+        this.errorView.update(stdout, cmd, true);
         if (atom.config.get('atom-phpunit.successAsNotifications')) {
           atom.notifications.addSuccess('Test Passed!', {description: cmd, detail: stdout});
         } else {

--- a/styles/atom-phpunit.less
+++ b/styles/atom-phpunit.less
@@ -27,6 +27,10 @@
     font-weight: 300;
   }
 
+  a {
+    color: #4f77d9;
+  }
+
   &.error {
     border-left-color: #660000;
 


### PR DESCRIPTION
This pull request simplifies the output view to show important information inline in the header and only shows individual test information in the content area. This also adds links to file paths so you can quickly navigate to a file and line number displayed in the stack trace.