### PR TITLE
Use test fallbacks instead of erroring

### DIFF
--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -46,7 +46,13 @@ export default {
       description: 'Set the font size of the PHPUnit Output view',
       type: 'string',
       default: '14px'
-    }
+    },
+    useTestFallback: {
+      order: 7,
+      description: 'Use fallback test if outside of test context',
+      type: 'boolean',
+      default: false
+    },
   },
 
   exec: null,
@@ -91,14 +97,23 @@ export default {
       this.outputPanel.hide();
     }
 
+    useTestFallback = atom.config.get('atom-phpunit.useTestFallback');
     filepath = this.getFilepath();
     if (!filepath) {
+      if (useTestFallback) {
+          return this.runLastTest();
+      }
+
       atom.notifications.addError('Failed to get filename! Make sure you are in the test file you want run.');
       return;
     }
 
     func = this.getFunctionName();
     if (!func) {
+      if (useTestFallback) {
+        return this.runClass();
+      }
+
       atom.notifications.addError('Function name not found! Make sure your cursor is inside the test you want to run.');
       return;
     }
@@ -113,6 +128,10 @@ export default {
     }
     filepath = this.getFilepath();
     if (!filepath) {
+      if (atom.config.get('atom-phpunit.useTestFallback')) {
+        return this.runLastTest();
+      }
+
       atom.notifications.addError('Failed to get filename! Make sure you are in the test file you want run.');
       return;
     }
@@ -126,7 +145,7 @@ export default {
       this.outputPanel.hide();
     }
 
-    filepath = this.getFilepath();
+    filepath = this.getFilepath(true);
     if (!filepath) {
       atom.notifications.addError('Failed to find phpunit! Make sure you are in the test file from the suit you want run.');
       return;
@@ -260,7 +279,7 @@ export default {
     return false
   },
 
-  getFilepath() {
+  getFilepath(skipTestCheck = false) {
     let editor = atom.workspace.getActivePaneItem();
     if (!editor)
       return false;
@@ -279,11 +298,18 @@ export default {
       return false;
     }
 
+    if (
+      (!atom.config.get('atom-phpunit.useTestFallback') || !skipTestCheck)
+      && !/test/i.test(file.path)
+    ) {
+      return false;
+    }
+
     return file.path;
   },
 
   getProjectFolderPath() {
-    return atom.project.relativizePath(this.getFilepath())[0];
+    return atom.project.relativizePath(this.getFilepath(true))[0];
   }
 
 };


### PR DESCRIPTION
Instead of displaying an error if test class or test method aren't found, run a fallback such as runClass if test method not found or runLastTest.