### PR TITLE
Fix cases when cmd is not being passed in

### DIFF
--- a/lib/atom-phpunit-view.js
+++ b/lib/atom-phpunit-view.js
@@ -49,7 +49,7 @@ export default class AtomPhpunitView {
     return this.element;
   }
 
-  update(data, cmd, success) {
+  update(data, cmd = '', success) {
     success
       ? this.element.classList.remove('error')
       : this.element.classList.add('error');

--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -186,13 +186,13 @@ export default {
     phpunit.stdout.on("data", (data) => {
       stdout += data.toString()
 
-      this.errorView.update(stdout, false);
+      this.errorView.update(stdout, cmd, false);
     });
 
     phpunit.stderr.on("data", (data) => {
       stderr += data.toString()
 
-      this.errorView.update(stderr, false);
+      this.errorView.update(stderr, cmd, false);
     });
 
     phpunit.on('exit', (code) => {


### PR DESCRIPTION
After merging in #16 and #20, there were a couple spots in #16 where cmd was not being passed in and throwing an error. This fixes that issue.