### PR TITLE
Listen to 'core:cancel' to hide the output panel.

### DIFF
--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import 'atom';
+import {CompositeDisposable} from 'atom';
 import Storage from './storage.js';
 import child_process from 'child_process';
 import AtomPhpunitView from './atom-phpunit-view.js';
@@ -66,6 +67,9 @@ export default {
       'atom-phpunit:run-last-test': () => this.runLastTest(),
       'atom-phpunit:toggle-output': () => this.toggleOutput()
     });
+
+    this.subscriptions = new CompositeDisposable;
+    this.subscriptions.add( atom.commands.add( 'atom-workspace', 'core:cancel', this.handleEditorCancel ));
   },
 
   serialize() {
@@ -77,6 +81,8 @@ export default {
   deactivate() {
     this.outputPanel.destroy();
     this.errorView.destroy();
+    this.subscriptions.dispose();
+    this.subscriptions = null;
   },
 
   runTest() {
@@ -149,6 +155,14 @@ export default {
     const {filepath, functionName} = this.lastTest
 
     this.execute(filepath, functionName);
+  },
+
+  handleEditorCancel: ({target}) => {
+      isMiniEditor = target.tagName === 'ATOM-TEXT-EDITOR' && target.hasAttribute('mini');
+      panelIsVisible = this.default.outputPanel && this.default.outputPanel.isVisible();
+      if ( !isMiniEditor && panelIsVisible ) {
+          this.default.outputPanel.hide()
+      }
   },
 
   toggleOutput() {


### PR DESCRIPTION
PR #17 inspired me to find out how other packages handle "escape to dismiss". I based this off of the implementation in [atom/find-and-replace](https://github.com/atom/find-and-replace/blob/master/lib/find.coffee) and it seems to be working smoothly for me. I do have some remaining questions, most of which might just be my unfamiliarity with ES/Node/Atom internals.

A few comments:
`handleEditorCancel` needs to be an arrow function in order for the subscription mechanism to work. If it's defined as a regular method property (like all of the other methods in this file) the scope isn't aligned and it can't access `this`.

Also, I 100% don't understand what the `this.default` is about w/i `handleEditorCancel`. I'm assuming that Atom/Node is injecting it as part of the async subscription mechanism, but I've never encountered it before.

So, this appears to work as expected, but the combination of these two concerns makes me want to get some extra review on this. If anyone can shed some light on this for me, I would appreciate it.

Thank you!