### PR TITLE
Add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,11 @@ There is also an option to control how success output is displayed, wither in th
 
 ## Preview
 ![Preview](https://github.com/Synapse791/atom-phpunit/raw/master/preview.gif)
+
+## Tests
+To run tests on this package:
+```sh
+$ git clone https://github.com/Synapse791/atom-phpunit.git
+$ cd atom-phpunit
+$ atom --test spec
+```

--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -217,6 +217,8 @@ export default {
         }
       }
     });
+
+    return phpunit
   },
 
   getFunctionName() {

--- a/spec/atom-phpunit-spec.js
+++ b/spec/atom-phpunit-spec.js
@@ -1,0 +1,85 @@
+'use babel';
+
+import AtomPhpunit from '../lib/atom-phpunit';
+
+const fixture = require.resolve('./fixtures/FixtureTest.php');
+
+describe('atom-phpunit', () => {
+
+    // activate the package and open the fixture file
+    beforeEach(() => {
+      waitsForPromise(() => atom.workspace.open(fixture, {initialLine: 7}))
+
+      runs(() => {
+        atom.packages.activatePackage('atom-phpunit')
+      })
+    })
+
+
+    it('can get the current file path', () => {
+        expect(AtomPhpunit.getFilepath()).toBe(fixture);
+    })
+
+    it('can get the current function name', () => {
+        expect(AtomPhpunit.getFunctionName()).toBe('test_method');
+    })
+
+
+    describe('when executing commands', () => {
+
+        // helper function to wait for async commands to run, then run a callback of expectations
+        const runCommandThen = (expectations) => {
+            let done = false;
+            runs(() => AtomPhpunit.execute().on('exit', () => done = true ))
+            waitsFor(() => done, "The command should be complete", 250 )
+            runs(expectations)
+        }
+
+        // spoof the command to just print a string
+        beforeEach(() => {
+            atom.config.set('atom-phpunit.useVendor',false)
+            atom.config.set('atom-phpunit.phpunitPath','php -r "echo \\\"the command has run\\\";"')
+        })
+
+        afterEach(() => {
+            atom.config.unset('atom-phpunit.useVendor')
+            atom.config.unset('atom-phpunit.phpunitPath')
+        });
+
+
+        it('succeeds and updates the output panel', () => {
+
+            runCommandThen(() => expect(AtomPhpunit.errorView.getElement().innerText).toMatch(/the command has run/))
+
+        })
+
+
+        describe('when notifications are being used', () => {
+
+            it('adds a notification', () => {
+
+                runCommandThen(() => {
+                    expect(atom.notifications.getNotifications().length).not.toBe(0)
+                    expect(AtomPhpunit.errorView.element.classList.contains('error')).toBe(false)
+                    expect(AtomPhpunit.outputPanel.isVisible()).toBe(false)
+                })
+
+            })
+        })
+
+
+        describe('when notifications are NOT being used', () => {
+
+            beforeEach(() => atom.config.set('atom-phpunit.successAsNotifications',false))
+            afterEach(() => atom.config.unset('atom-phpunit.successAsNotifications'))
+
+            it('displays the output panel', () => {
+
+                expect(AtomPhpunit.outputPanel.isVisible()).toBe(false)
+
+                runCommandThen(() => expect(AtomPhpunit.outputPanel.isVisible()).toBe(true))
+
+            })
+        })
+    })
+})

--- a/spec/atom-phpunit-view-spec.js
+++ b/spec/atom-phpunit-view-spec.js
@@ -1,0 +1,58 @@
+'use babel';
+
+import fs from 'fs';
+import AtomPhpunitView from '../lib/atom-phpunit-view';
+
+const fixtures = {
+    pass: fs.readFileSync(require.resolve('./fixtures/phpunit_output_passing.txt')).toString(),
+    fail: fs.readFileSync(require.resolve('./fixtures/phpunit_output_failing.txt')).toString(),
+};
+
+describe('atom-phpunit-view', () => {
+
+    let view = new AtomPhpunitView;
+
+    describe('cleans the phpunit output', () => {
+
+        it('from passing tests', () => {
+
+            expect(view.getCleanOutput(fixtures.pass)).not.toMatch(/PHPUnit/)
+            expect(view.getCleanOutput(fixtures.pass)).not.toMatch(/OK/)
+
+        })
+
+        it('from failing tests', () => {
+
+            expect(view.getCleanOutput(fixtures.fail)).not.toMatch(/PHPUnit/)
+            expect(view.getCleanOutput(fixtures.fail)).not.toMatch(/Failures/)
+
+        })
+
+    })
+
+    describe('creates an updated header', () => {
+
+        let command = 'vendor/bin/phpunit'
+
+        it('for passing tests', () => {
+
+            expect(view.getUpdatedHeader(fixtures.pass,command)).toMatch(/OK/)
+
+        })
+
+        it('for failing tests', () => {
+
+            expect(view.getUpdatedHeader(fixtures.fail,command)).toMatch(/Failures: 1/)
+
+        })
+
+        it('for unrecognized output', () => {
+
+            expect(view.getUpdatedHeader('this is unrecognized output',command)).toMatch(/PHPUnit Output/)
+
+        })
+
+    })
+
+
+});

--- a/spec/fixtures/FixtureTest.php
+++ b/spec/fixtures/FixtureTest.php
@@ -1,0 +1,9 @@
+<?php
+
+class FixtureTest
+{
+    public function test_method()
+    {
+        $this->assertTrue("this is not a real test");
+    }
+}

--- a/spec/fixtures/phpunit_output_failing.txt
+++ b/spec/fixtures/phpunit_output_failing.txt
@@ -1,0 +1,15 @@
+PHPUnit 6.4.4 by Sebastian Bergmann and contributors.
+
+F                                                                   1 / 1 (100%)
+
+Time: 36 ms, Memory: 4.00MB
+
+There was 1 failure:
+
+1) AllTheTest::test_failing
+Failed asserting that true is false.
+
+/Users/user/atom-phpunit-fixtures/tests/AllTheTest.php:15
+
+FAILURES!
+Tests: 1, Assertions: 1, Failures: 1.

--- a/spec/fixtures/phpunit_output_passing.txt
+++ b/spec/fixtures/phpunit_output_passing.txt
@@ -1,0 +1,7 @@
+PHPUnit 6.4.4 by Sebastian Bergmann and contributors.
+
+.                                                                   1 / 1 (100%)
+
+Time: 44 ms, Memory: 4.00MB
+
+OK (1 test, 1 assertion)


### PR DESCRIPTION
This was a great excuse to learn about testing Atom packages. Nothing too fancy: most of the tests are for helper methods, but there are a few that try to test that the test command is actually run, and that it updates the UI accordingly.

```
$ atom --test spec
..........

Finished in 0.618 seconds
10 tests, 15 assertions, 0 failures, 0 skipped
```