### PR TITLE
Update the clickable filenames in output to handle "on line xyz"

### DIFF
--- a/lib/atom-phpunit-view.js
+++ b/lib/atom-phpunit-view.js
@@ -25,7 +25,7 @@ export default class AtomPhpunitView {
 
     output.addEventListener("click", function(e) {
       if(e.target && e.target.nodeName == "A") {
-        atom.open({pathsToOpen: [e.target.textContent]});
+        atom.open({pathsToOpen: [e.target.dataset.path]});
       }
     });
 
@@ -98,7 +98,11 @@ export default class AtomPhpunitView {
     input = input.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
       return '&#'+i.charCodeAt(0)+';';
     });
-    input = input.replace(/((([A-Z]\\:)?([\\/]+(\w|-|_|\.)+)+(\.(\w|-|_)+)+(:\d+)?))/g, '<a>$1</a>');
+
+    // turn file names & line numbers into links
+    input = input
+        .replace(/((([A-Z]\\:)?([\\/]+(\w|-|_|\.)+)+(\.(\w|-|_)+)+((:| on line )\d+)?))/g, '<a data-path="$1">$1</a>')
+        .replace(/<a data-path="(.+) on line (\d+)">/g, '<a data-path="$1:$2">');
 
     return input.trim();
   }


### PR DESCRIPTION
When I work with legacy code, I often encounter PHP notices with formats like:
```
PHP Notice:  Undefined variable: this_variable_doesnt_exist in /path/to/some/file.php on line 1234
```

This PR updates clickable-filename code to detect and handle this style of output so that we can click on the filename and jump right to the line in question.

Thanks!