### PR TITLE
support dataProvider test names when filtering single tests (closes #30)

### DIFF
--- a/lib/atom-phpunit.js
+++ b/lib/atom-phpunit.js
@@ -184,8 +184,10 @@ export default {
     else
       cmd = atom.config.get('atom-phpunit.phpunitPath');
 
+    // this filter needs to support normal test names (eg "Class@method")
+    // and dataProvider test names (eg "Class@method with data set ...")
     if (typeof functionName !== 'undefined')
-      cmd += ` --filter=${functionName}$`;
+      cmd += ` --filter='${functionName}(\\swith.+)?$'`;
 
     if (typeof filepath !== 'undefined')
       cmd += ` ${filepath}`;


### PR DESCRIPTION
As the name says, this updates the single test filter to support tests that are run w/ dataProviders. As you can see in the diff, the filter regex was changed as such:
```
old: --filter=${functionName}$
new: --filter='${functionName}(\\swith.+)?$'
```

Note the addition of single quotes so that the regex gets to phpUnit OK. (w/o them, the shell gives a syntax error b/c of the parens.) Shell escaping is also the reason for the `\\s` instead of just `\s`.

I don't believe that we're running any automated tests w/ phpUnit, so I didn't add any tests, but the existing tests still work. I have tested this locally and it it appears to work just fine with and without dataProvider tests.